### PR TITLE
Ensure we use merge-commits.py even if working directory is changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ RUN apk add --no-cache \
     git
 
 # Copy files to container
-COPY *.py .
+COPY . /app
 
 # Mark script as executable.
 RUN chmod u+x merge-commits.py
 
 # Command to run the executable
-ENTRYPOINT ["python3", "merge-commits.py"]
+ENTRYPOINT ["python3", "/app/merge-commits.py"]

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'A GitHub action to find all of the commits in a PR/Branch merge.'
 author: 'autamus'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/autamus/merge-commits:latest'
+  image: 'Dockerfile'
 branding:
   icon: 'activity'  
   color: 'blue'


### PR DESCRIPTION
This PR fixes 2 bugs, and one question for how the action is deployed.

1. Currently, since the entrypoint doesn't have a directory name, the action will fail if the runner changes the workdir (it failed for me on first test). So I just updated the entrypoint to be /app/merge-commits.py
2. I realized that the container isn't being built from the Dockerfile (is there a reason for this?) it just makes it harder to test a branch. But if it's to ensure that nobody does anything malicious, that works.
3. Adding both files via *.py to . seemed to trigger an exit on 1 immediately in the GitHub action, so I changed to COPY . to /app


Signed-off-by: vsoch <vsoch@users.noreply.github.com>